### PR TITLE
Return RPC from Lotion.connect()

### DIFF
--- a/index.js
+++ b/index.js
@@ -309,6 +309,7 @@ Lotion.connect = function(GCI, opts = {}) {
 
     let methods = {
       bus,
+      rpc,
       getState: async function(path = '') {
         let queryResponse = await axios.get(
           `${fullNodeRpcAddress}/abci_query?path=""`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lotion",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lotion",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "smooth, easy blockchain apps. powered by tendermint consensus.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
returning the rpc object from Lotion.connect enables other services
running on the same machine as lotion to easily use RPC, i.e. subscribe
to events without duplicating effort.